### PR TITLE
Add support for inline '//' and '/* */' comments

### DIFF
--- a/armsim.py
+++ b/armsim.py
@@ -284,8 +284,14 @@ def parse(lines)->None:
         line = line.strip()
         #convert multiple spaces into one space 
         line = re.sub('[ \t]+',' ',line) 
-        if('/*' in line and '*/' in line):continue
-        if('//' in line):continue
+        if('/*' in line and '*/' in line):
+            a = line.index('/*')
+            b = line.index('*/')
+            line = (line[:a] + line[b+2:]).strip() #line = everything before /* + everything after */
+            if not line: continue
+        if('//' in line):
+            line = line[:line.index('//')].strip() #line = everything before //
+            if not line: continue
         if("/*" in line):comment = True;continue
         if("*/" in line):comment = False;continue
         if(".data" in line):data = True;code = False;bss = False;continue

--- a/documentation/armsim_guide.md
+++ b/documentation/armsim_guide.md
@@ -85,14 +85,7 @@ These are the current supported instructions. The instruction formats comes from
     svc 0        
 
     
-### Comments 
-(Must ***NOT*** be on same line as stuff you want read into the program, since the parser throws away lines with comments):
 
-    //text
-    /*text*/
-    /*
-    text
-    */
 -----
 ##  Debugger
 The debugger has been moved to a standalone program called armdb. See [the guide](armdb_guide.md) for usage instructions

--- a/tests/comments_test.s
+++ b/tests/comments_test.s
@@ -1,0 +1,53 @@
+.text
+.global _start
+
+_start:
+
+
+main:
+  /*****************
+  * This test is a derivative of the more readable 
+  * 'arithmetic_test.s'. The functionality reamins, 
+  * however, the program is meant to succeed if the 
+  * parser can correctly parse comments.
+  ******************/
+
+    //exit code should be 7
+    mov x0, 7           //  ALPHA
+    mov x1, x0          //  BETA
+
+    add x0, x0, 1234    /* GAMMA */ 
+    /* DELTA */ sub x0, x0, 1200   
+
+    sub x0,/* EPSILON */x0, 34
+    
+    /*
+    * ZETA 
+    */mov x2, 0xffffffff 
+    /*
+    * ETA
+    */mul x0, x0, x2 /*
+    * THETA
+    */udiv x0, x0, x2 /*
+    * IOTA
+    */
+
+    lsl x0, x0, 6 /* KAPPA *//* LAMBDA */
+    /* MU */lsl /* NU */x0,/* XI */ x0/*OMNICRON*/, 6
+    asr x0, x0, 3
+    asr x0, x0, 9
+
+
+
+    mov x2,2
+    mov x3,3
+    msub x0,x2,x3,x0
+    madd x0,x2,x3,x0
+
+    cmp x0,x1
+    b.eq correct
+    mov x0,-1
+correct:
+    /* exit */
+    mov x8, #93
+    svc #0


### PR DESCRIPTION
As noted in armv8-examples/documentation/armsim_guide.md, the parser did not support inline comments. This commit adds that support.

Examples that now work:
	mov x0, #0 // hello world
	mov x1, #0 /* hello world */